### PR TITLE
disable create_reference_number

### DIFF
--- a/ups.py
+++ b/ups.py
@@ -229,7 +229,7 @@ class UPS(object):
         classification = client.factory.create('ns2:CodeDescriptionType')
         classification.Code = '00' # Get rates for the shipper account
 
-        shipment = self._create_shipment(client, packages, shipper, recipient, packaging_type, namespace='ns2')
+        shipment = self._create_shipment(client, packages, shipper, recipient, packaging_type, namespace='ns2', create_reference_number=False)
         shipment.ShipmentRatingOptions.NegotiatedRatesIndicator = ''
 
         try:


### PR DESCRIPTION
this fixes the following errors when using the rate():

ERROR:suds.resolver:(ns2:ReferenceNumberType) not-found
ERROR:suds.resolver:path: "ns2:ReferenceNumberType", not-found

This should be fixed at a later point.
